### PR TITLE
nlp-mi without objective

### DIFF
--- a/src/nlp-mi/004_012.jl
+++ b/src/nlp-mi/004_012.jl
@@ -1,0 +1,23 @@
+function nlp_mi_004_012(optimizer, objective_tol, primal_tol, dual_tol,
+    termination_target = TERMINATION_TARGET_LOCAL,
+    primal_target = PRIMAL_TARGET_LOCAL)
+
+    # Test Goals:
+    # - feasible model
+    # - no objective
+    # - discrete and non-discrete variables
+
+    m = Model(optimizer)
+
+    @variable(m, -1 <= x <= 1)
+    @variable(m, y)
+    @variable(m, z, Int)
+
+    @NLconstraint(m, x^2 + y^2 + z^2 <= 10)
+    @NLconstraint(m, -1.2*x - y <= z/1.35)
+    optimize!(m)
+
+    check_status(m, FEASIBLE_PROBLEM, termination_target, primal_target)
+    # 0.0 as it doesn't have an objective
+    check_objective(m, 0.0, tol = objective_tol)
+end


### PR DESCRIPTION
Coming from https://github.com/lanl-ansi/Juniper.jl/issues/195
Seems like there was only one test case without an objective. This one adds another one which has an unbounded variable as well as a discrete and a bounded one. Juniper had problems in the feasibility pump if there was no objective but not all variables were discrete.

BTW I have not understood the naming scheme of the files. I tried to fit in but maybe I failed.

@ccoffrin you might wanna have a look.