### PR TITLE
Make MINLPTests compatible with JuMP 0.22

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "MINLPTests"
 uuid = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
 repo = "https://github.com/jump-dev/MINLPTests.jl.git"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Ipopt = "0.6"
+Ipopt = "0.6, 0.7, 0.8"
 JuMP = "0.21, 0.22"
 Juniper = "0.7"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Ipopt = "0.6"
-JuMP = "0.21"
+JuMP = "0.21, 0.22"
 Juniper = "0.7"
 julia = "1"
 


### PR DESCRIPTION
Add a new compatible entry in `Project.toml`, in a way that MINLPTests is compatible both with JuMP 0.21 and JuMP 0.22. 

Testing locally, both Knitro and MadNP pass the tests with JuMP 0.22 and MINLPTests.

We can not force MINLPTests to use JuMP 0.22, as Juniper is not compatible with that version yet.